### PR TITLE
Fixed Switching to a raining gold lane

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -494,7 +494,7 @@ function goToLaneWithBestTarget() {
 		}
 
 		//Prefer lane with raining gold, unless current enemy target is a treasure or boss.
-		if(lowTarget != ENEMY_TYPE.TREASURE && lowTarget != ENEMY_TYPE.BOSS ){
+		if(!targetIsTreasureOrBoss){
 			var potential = 0;
 			// Loop through lanes by elemental preference
 			var sortedLanes = sortLanesByElementals();


### PR DESCRIPTION
lowTarget is always zero at that point, so the code will execute all the time. And besides, lowTarget would be the id of the enemy and not the type.
