### PR TITLE
auto-refresh option if the user is using GM or TM

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This fork has:
 * Auto use abilities
 * idk
 
+** This fork is designed for use as a group (specifically the MSG2015 Steam group). **
+
 
 **DISCLAIMER:** This autoscript *will* include an auto-clicker. Automatic clicking pushes into the area of cheating, and this script is designed for cheating and automating the process of collecting gold.
 
@@ -43,12 +45,12 @@ This fork has:
 
 1. Open Tapermonkey's dashboard.
 2. Click on the `Utilites` tab on the right.
-3. Paste `https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js` into the text area, and click `Import`.
+3. Paste `https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js` into the text area, and click `Import`.
 4. When the editor has loaded, click `Install` (*NOT* `Process with Chrome`).
 
 ### Greasemonkey ###
 
-1. Navigate to `https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js`.
+1. Navigate to `https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js`.
 2. Right click on the page, and click `Save Page As`.
 3. While Firefox is still open, open a File Manager of any sort, and navigate to the directory you saved the script.
 4. Drag & drop the script file onto the Firefox window.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This fork has:
 * Auto use abilities
 * idk
 
-** This fork is designed for use as a group (specifically the MSG2015 Steam group). **
-
 
 **DISCLAIMER:** This autoscript *will* include an auto-clicker. Automatic clicking pushes into the area of cheating, and this script is designed for cheating and automating the process of collecting gold.
 
@@ -48,12 +46,12 @@ This fork has:
 
 1. Open Tapermonkey's dashboard.
 2. Click on the `Utilites` tab on the right.
-3. Paste `https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js` into the text area, and click `Import`.
+3. Paste `https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js` into the text area, and click `Import`.
 4. When the editor has loaded, click `Install` (*NOT* `Process with Chrome`).
 
 ### [Greasemonkey](https://addons.mozilla.org/en-us/firefox/addon/greasemonkey/) ###
 
-1. Navigate to `https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js`.
+1. Navigate to `https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js`.
 2. Right click on the page, and click `Save Page As`.
 3. While Firefox is still open, open a File Manager of any sort, and navigate to the directory you saved the script.
 4. Drag & drop the script file onto the Firefox window.

--- a/README.md
+++ b/README.md
@@ -40,16 +40,15 @@ This fork has:
 - Disables certain abilities and items if facing a Boss (to try to maximize Raining Gold and Metal Detector benefits)
 
 ## Installation ##
-**It is recommended to use either [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) (Chrome) or [Greasemonkey](https://addons.mozilla.org/en-us/firefox/addon/greasemonkey/) (Firefox).** This allows the script to auto-update to the most recent version. The rate of this update can be changed in each extension's preferences.
 
-### [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) ###
+### Tampermonkey ###
 
 1. Open Tapermonkey's dashboard.
 2. Click on the `Utilites` tab on the right.
 3. Paste `https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js` into the text area, and click `Import`.
 4. When the editor has loaded, click `Install` (*NOT* `Process with Chrome`).
 
-### [Greasemonkey](https://addons.mozilla.org/en-us/firefox/addon/greasemonkey/) ###
+### Greasemonkey ###
 
 1. Navigate to `https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js`.
 2. Right click on the page, and click `Save Page As`.

--- a/README.md
+++ b/README.md
@@ -40,15 +40,16 @@ This fork has:
 - Disables certain abilities and items if facing a Boss (to try to maximize Raining Gold and Metal Detector benefits)
 
 ## Installation ##
+**It is recommended to use either [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) (Chrome) or [Greasemonkey](https://addons.mozilla.org/en-us/firefox/addon/greasemonkey/) (Firefox).** This allows the script to auto-update to the most recent version. The rate of this update can be changed in each extension's preferences.
 
-### Tampermonkey ###
+### [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) ###
 
 1. Open Tapermonkey's dashboard.
 2. Click on the `Utilites` tab on the right.
 3. Paste `https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js` into the text area, and click `Import`.
 4. When the editor has loaded, click `Install` (*NOT* `Process with Chrome`).
 
-### Greasemonkey ###
+### [Greasemonkey](https://addons.mozilla.org/en-us/firefox/addon/greasemonkey/) ###
 
 1. Navigate to `https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js`.
 2. Right click on the page, and click `Save Page As`.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ This fork has:
 
 **DISCLAIMER:** This autoscript *will* include an auto-clicker. Automatic clicking pushes into the area of cheating, and this script is designed for cheating and automating the process of collecting gold.
 
-**Notice:** The script 'auto-clicks' a combined ammount once a second, so it may seems as if it isn't auto-clicking. The Raining Gold and damage values are combined and processed once a second to be more efficient and reduce client load (as compared to the previous method of simulating 20 clicks-per-second). As long as the 'Enable autoclicker' is checked at the bottom of the screen in the options box, it is autoclicking.
-
 ## Features ##
 
 - Moves you to the lane most likely to give you gold, prioritized like so:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This fork has:
 
 **DISCLAIMER:** This autoscript *will* include an auto-clicker. Automatic clicking pushes into the area of cheating, and this script is designed for cheating and automating the process of collecting gold.
 
+**Notice:** The script 'auto-clicks' a combined ammount once a second, so it may seems as if it isn't auto-clicking. The Raining Gold and damage values are combined and processed once a second to be more efficient and reduce client load (as compared to the previous method of simulating 20 clicks-per-second). As long as the 'Enable autoclicker' is checked at the bottom of the screen in the options box, it is autoclicking.
+
 ## Features ##
 
 - Moves you to the lane most likely to give you gold, prioritized like so:

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -27,7 +27,7 @@ var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
 
-if (GM_info !== "undefined") {
+if (typeof GM_info !== "undefined") {
 	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh for GM/TM users
 } else {
 	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // no auto-refresh for non-GM/TM users

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshSeconds = 60; // refresh page after x seconds
+var autoRefreshSeconds = 120; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -71,6 +71,8 @@ var ENEMY_TYPE = {
 	"MINIBOSS":3,
 	"TREASURE":4
 };
+
+var refreshTimer = null; // global to cancel running timers if disabled after timer has already started
 
 
 function firstRun() {
@@ -292,7 +294,7 @@ function toggleAutoRefresh(event) {
     if(value) {
         autoRefreshPage(autoRefreshSeconds);
     } else {
-		enableAutoRefresh = false;	
+		clearTimeout(refreshTimer);	
     }
 }
 
@@ -1094,12 +1096,7 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	if(enableAutoRefresh) {
-		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
-	}
-	else {
-		console.log("auto-refresh has been disabled, so no refresh);
-	}
+	refreshTimer = setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -174,7 +174,6 @@ function firstRun() {
 	checkboxes.appendChild(makeCheckBox("removeCritText", "Remove crit text", removeCritText, toggleCritText));
 	checkboxes.appendChild(makeCheckBox("removeAllText", "Remove all text (overrides above)", removeAllText, toggleAllText));
 	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
-	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
 	info_box.appendChild(checkboxes);
 	
 	enhanceTooltips();

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1101,7 +1101,7 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	refreshTimer = setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	refreshTimer = setTimeout(function(){w.location.reload(true);},autoRefreshSeconds*1000);
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -16,7 +16,7 @@
 "use strict";
 
 // OPTIONS
-var clickRate = 20;
+var clickRate = 10;
 var logLevel = 1; // 5 is the most verbose, 0 disables all log
 
 var enableAutoClicker = getPreferenceBoolean("enableAutoClicker", true);

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshSeconds = 120; // refresh page after x seconds
+var autoRefreshSeconds = 1800; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name Monster Minigame Auto-script w/ auto-click
-// @namespace https://github.com/SteamDatabase/steamSummerMinigame
+// @namespace https://github.com/wchill/steamSummerMinigame
 // @description A script that runs the Steam Monster Minigame for you.
 // @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
 // @grant none
-// @updateURL https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js
-// @downloadURL https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js
+// @updateURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
+// @downloadURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // ==/UserScript==
 
 // IMPORTANT: Update the @version property above to a higher number such as 1.1 and 1.2 when you update the script! Otherwise, Tamper / Greasemonkey users will not update automatically.

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -5,7 +5,7 @@
 // @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
-// @grant none 
+// @grant none
 // @updateURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // @downloadURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // ==/UserScript==

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshSeconds = 1800; // refresh page after x seconds
+var autoRefreshMinutes = 30; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -137,7 +137,7 @@ function firstRun() {
 	}
 
 	if (enableAutoRefresh) {
-		autoRefreshPage(autoRefreshSeconds);
+		autoRefreshPage(autoRefreshMinutes);
 	}
 
 	if (w.CSceneGame !== undefined) {
@@ -293,7 +293,7 @@ function toggleAutoRefresh(event) {
     if(event !== undefined)
         value = handleCheckBox(event);
     if(value) {
-        autoRefreshPage(autoRefreshSeconds);
+        autoRefreshPage(autoRefreshMinutes);
     } else {
 		clearTimeout(refreshTimer);	
     }
@@ -1096,8 +1096,8 @@ function getClickDamage(){
     return g_Minigame.m_CurrentScene.m_rgPlayerTechTree.damage_per_click;
 }
 
-function autoRefreshPage(autoRefreshSeconds){
-	refreshTimer = setTimeout(function(){w.location.reload(true);},autoRefreshSeconds*1000);
+function autoRefreshPage(autoRefreshMinutes){
+	refreshTimer = setTimeout(function(){w.location.reload(true);},autoRefreshMinutes*1000*60);
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -5,7 +5,7 @@
 // @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
-// @grant none
+// @grant none 
 // @updateURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // @downloadURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // ==/UserScript==
@@ -26,7 +26,7 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
-var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh the page to clear out stale memory from leak
+var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // auto-refresh the page to clear out stale memory from leak
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
@@ -167,7 +167,9 @@ function firstRun() {
 	checkboxes.style["column-count"] = 2;
 	
 	checkboxes.appendChild(makeCheckBox("enableAutoClicker", "Enable autoclicker", enableAutoClicker, toggleAutoClicker));
-	checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
+	if (typeof GM_info !==  "undefined") {
+		checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
+	};
 	checkboxes.appendChild(makeCheckBox("removeInterface", "Remove interface (needs refresh)", removeInterface, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeParticles", "Remove particle effects (needs refresh)", removeParticles, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeFlinching", "Remove flinching effects (needs refresh)", removeFlinching, handleEvent));

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -26,12 +26,8 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
+var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info !== "undefined");
 
-if (typeof GM_info !== "undefined") {
-	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh for GM/TM users
-} else {
-	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // no auto-refresh for non-GM/TM users
-}
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
 var autoRefreshSeconds = 1800; // refresh page after x seconds

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -169,7 +169,7 @@ function firstRun() {
 	checkboxes.appendChild(makeCheckBox("enableAutoClicker", "Enable autoclicker", enableAutoClicker, toggleAutoClicker));
 	if (typeof GM_info !==  "undefined") {
 		checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
-	};
+	}
 	checkboxes.appendChild(makeCheckBox("removeInterface", "Remove interface (needs refresh)", removeInterface, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeParticles", "Remove particle effects (needs refresh)", removeParticles, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeFlinching", "Remove flinching effects (needs refresh)", removeFlinching, handleEvent));

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -2,7 +2,7 @@
 // @name Monster Minigame Auto-script w/ auto-click
 // @namespace https://github.com/SteamDatabase/steamSummerMinigame
 // @description A script that runs the Steam Monster Minigame for you.
-// @version 3.6.5
+// @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
 // @grant none

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -2,7 +2,7 @@
 // @name Monster Minigame Auto-script w/ auto-click
 // @namespace https://github.com/SteamDatabase/steamSummerMinigame
 // @description A script that runs the Steam Monster Minigame for you.
-// @version 3.7.0
+// @version 3.6.5
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
 // @grant none

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -26,8 +26,11 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
+var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh the page to clear out stale memory from leak
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
+
+var autoRefreshSeconds = 60; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -131,6 +134,10 @@ function firstRun() {
 		document.body.style.backgroundPosition = "0 0";
 	}
 
+	if (enableAutoRefresh) {
+		autoRefreshPage(autoRefreshSeconds);
+	}
+
 	if (w.CSceneGame !== undefined) {
 		w.CSceneGame.prototype.DoScreenShake = function() {};
 	}
@@ -158,11 +165,13 @@ function firstRun() {
 	checkboxes.style["column-count"] = 2;
 	
 	checkboxes.appendChild(makeCheckBox("enableAutoClicker", "Enable autoclicker", enableAutoClicker, toggleAutoClicker));
+	checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
 	checkboxes.appendChild(makeCheckBox("removeInterface", "Remove interface (needs refresh)", removeInterface, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeParticles", "Remove particle effects (needs refresh)", removeParticles, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeFlinching", "Remove flinching effects (needs refresh)", removeFlinching, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeCritText", "Remove crit text", removeCritText, toggleCritText));
 	checkboxes.appendChild(makeCheckBox("removeAllText", "Remove all text (overrides above)", removeAllText, toggleAllText));
+	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
 	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
 	info_box.appendChild(checkboxes);
 	
@@ -273,6 +282,17 @@ function toggleAutoClicker(event) {
         currentClickRate = clickRate;
     } else {
         currentClickRate = 0;
+    }
+}
+
+function toggleAutoRefresh(event) {
+    var value = enableAutoRefresh;
+    if(event !== undefined)
+        value = handleCheckBox(event);
+    if(value) {
+        autoRefreshPage(autoRefreshSeconds);
+    } else {
+		autoRefreshSeconds = 0;
     }
 }
 
@@ -1071,6 +1091,12 @@ function getDPS(){
 
 function getClickDamage(){
     return g_Minigame.m_CurrentScene.m_rgPlayerTechTree.damage_per_click;
+}
+
+function autoRefreshPage(autoRefreshSeconds){
+	if(autoRefreshSeconds > 0) {
+		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	}
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -16,7 +16,7 @@
 "use strict";
 
 // OPTIONS
-var clickRate = 10;
+var clickRate = 20;
 var logLevel = 1; // 5 is the most verbose, 0 disables all log
 
 var enableAutoClicker = getPreferenceBoolean("enableAutoClicker", true);

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshMinutes = 30; // refresh page after x seconds
+var autoRefreshMinutes = 30; // refresh page after x minutes 
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -292,7 +292,7 @@ function toggleAutoRefresh(event) {
     if(value) {
         autoRefreshPage(autoRefreshSeconds);
     } else {
-		autoRefreshSeconds = 0;
+		enableAutoRefresh = false;	
     }
 }
 
@@ -1094,9 +1094,7 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	if(autoRefreshSeconds > 0) {
-		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
-	}
+	setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name Monster Minigame Auto-script w/ auto-click
-// @namespace https://github.com/wchill/steamSummerMinigame
+// @namespace https://github.com/SteamDatabase/steamSummerMinigame
 // @description A script that runs the Steam Monster Minigame for you.
 // @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
 // @grant none
-// @updateURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
-// @downloadURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
+// @updateURL https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js
+// @downloadURL https://raw.githubusercontent.com/SteamDatabase/steamSummerMinigame/master/autoPlay.user.js
 // ==/UserScript==
 
 // IMPORTANT: Update the @version property above to a higher number such as 1.1 and 1.2 when you update the script! Otherwise, Tamper / Greasemonkey users will not update automatically.

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1094,7 +1094,12 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	if(enableAutoRefresh) {
+		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	}
+	else {
+		console.log("auto-refresh has been disabled, so no refresh);
+	}
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -26,8 +26,12 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
-var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // auto-refresh the page to clear out stale memory from leak
 
+if (GM_info !== "undefined") {
+	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh for GM/TM users
+} else {
+	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // no auto-refresh for non-GM/TM users
+}
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
 var autoRefreshSeconds = 1800; // refresh page after x seconds


### PR DESCRIPTION
Pull from wchill fork.

Adding an auto-refresh option to the options to allow users to auto-refresh the page to 'fix' the memory leak without a third-party extension. Default time is 30 minutes. This defaults to 'enabled' for users of GM/TM, and defaults to 'disabled' for copy/paste scripts, as well as not showing the checkbox to enable, as refreshing the page would wipe their script.
