### PR TITLE
Removed duplicate checkbox options

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -206,8 +206,6 @@ function firstRun() {
 	}
 
 	options2.appendChild(makeCheckBox("enableFingering", "Enable targeting pointer", enableFingering, handleEvent,true));
-	options2.appendChild(makeCheckBox("removeCritText", "Remove crit text", removeCritText, toggleCritText));
-	options2.appendChild(makeCheckBox("removeAllText", "Remove all text (overrides above)", removeAllText, toggleAllText));
 	options2.appendChild(makeNumber("setLogLevel", "Change the log level (you shouldn't need to touch this)", "25px", logLevel, 0, 5, updateLogLevel));
 
 	info_box.appendChild(options2);


### PR DESCRIPTION
"Remove Crit Text" and "Remove All Text" were duplicated.
