### PR TITLE
Auto-use Max Elemental Damage and Treasure Fix

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1174,7 +1174,7 @@ function useTreasureIfRelevant() {
 function useMaxElementalDmgIfRelevant() {
 	// Check if Max Elemental Damage is purchased
 	if (hasItem(ITEMS.MAXIMIZE_ELEMENT)) {
-		if (isAbilityCoolingDown(ITEMS.MAXIMIZE_ELEMENT) || !canUseItem(ITEMS.MAXIMIZE_ELEMENT) || isAbilityActive(ITEMS.MAXIMIZE_ELEMENT)) {
+		if (isAbilityCoolingDown(ITEMS.MAXIMIZE_ELEMENT) || !canUseItem(ITEMS.MAXIMIZE_ELEMENT) || getActiveAbilityLaneCount(ITEMS.MAXIMIZE_ELEMENT) > 0) {
 			return;
 		}
 		else {

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1143,7 +1143,7 @@ function useMetalDetectorIfRelevant() {
 function useTreasureIfRelevant() {
 	// Check if Treasure is purchased 
 	if (hasItem(ITEMS.TREASURE)) {
-		if (isAbilityCoolingDown(ITEMS.TREASURE) || isAbilityActive(ABILITIES.METAL_DETECTOR)) {
+		if (isAbilityCoolingDown(ITEMS.TREASURE)) {
 			return;
 		}
 		

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1174,10 +1174,7 @@ function useTreasureIfRelevant() {
 function useMaxElementalDmgIfRelevant() {
 	// Check if Max Elemental Damage is purchased
 	if (hasItem(ITEMS.MAXIMIZE_ELEMENT)) {
-		if (isAbilityCoolingDown(ITEMS.MAXIMIZE_ELEMENT) || !canUseItem(ITEMS.MAXIMIZE_ELEMENT) || getActiveAbilityLaneCount(ITEMS.MAXIMIZE_ELEMENT) > 0) {
-			return;
-		}
-		else {
+		if (!isAbilityCoolingDown(ITEMS.MAXIMIZE_ELEMENT) && canUseItem(ITEMS.MAXIMIZE_ELEMENT) && getActiveAbilityLaneCount(ITEMS.MAXIMIZE_ELEMENT) <= 0) {
 			// Max Elemental Damage is purchased, cooled down, and needed. Trigger it.
 			advLog('Max Elemental Damage is purchased and cooled down, triggering it.', 2);
 			triggerItem(ITEMS.MAXIMIZE_ELEMENT);

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -271,6 +271,7 @@ function MainLoop() {
 		useCrippleMonsterIfRelevant();
 		useReviveIfRelevant();
 		useTreasureIfRelevant();
+		useMaxElementalDmgIfRelevant();
 
 		disableCooldownIfRelevant();
 
@@ -1166,6 +1167,20 @@ function useTreasureIfRelevant() {
 			// Treasure is purchased, cooled down, and needed. Trigger it.
 			advLog('Treasure is purchased and cooled down, triggering it.', 2);
 			triggerItem(ITEMS.TREASURE);
+		}
+	}
+}
+
+function useMaxElementalDmgIfRelevant() {
+	// Check if Max Elemental Damage is purchased
+	if (hasItem(ITEMS.MAXIMIZE_ELEMENT)) {
+		if (isAbilityCoolingDown(ITEMS.MAXIMIZE_ELEMENT) || !canUseItem(ITEMS.MAXIMIZE_ELEMENT) || isAbilityActive(ITEMS.MAXIMIZE_ELEMENT)) {
+			return;
+		}
+		else {
+			// Max Elemental Damage is purchased, cooled down, and needed. Trigger it.
+			advLog('Max Elemental Damage is purchased and cooled down, triggering it.', 2);
+			triggerItem(ITEMS.MAXIMIZE_ELEMENT);
 		}
 	}
 }


### PR DESCRIPTION
Auto-uses Max Elemental Damage whenever you can and while it's not active in the lane.
Fixes Treasure to stack with Metal Detector.
