### PR TITLE
Restricted Raining Gold activation

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1155,12 +1155,16 @@ function useGoldRainIfRelevant() {
 			return;
 		}
 
+		if (Math.random() > s().CurrentScene().m_rgGameData.level / 10000) {
+			return;
+		}
+
 		var enemy = s().GetEnemy(s().m_rgPlayerData.current_lane, s().m_rgPlayerData.target);
 		// check if current target is a boss, otherwise its not worth using the gold rain
 		if (enemy && enemy.m_data.type == ENEMY_TYPE.BOSS) {
 			var enemyBossHealthPercent = enemy.m_flDisplayedHP / enemy.m_data.max_hp;
 
-			if (enemyBossHealthPercent >= 0.6) { // We want sufficient time for the gold rain to be applicable
+			if (enemyBossHealthPercent >= 0.3) { // We want sufficient time for the gold rain to be applicable
 				// Gold Rain is purchased, cooled down, and needed. Trigger it.
 				advLog('Gold rain is purchased and cooled down, Triggering it on boss', 2);
 				triggerItem(ITEMS.GOLD_RAIN);


### PR DESCRIPTION
-Added check to ensure game is at certain level before Raining Gold can be activated, because the gold gained at lower levels is fairly insignificant.
-Widened the band of boss health that Raining Gold can be activated in, due to the previously mentioned level restriction.
