### PR TITLE
Permanently disable throw money ability

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -262,6 +262,8 @@ function MainLoop() {
 	if (!isAlreadyRunning) {
 		isAlreadyRunning = true;
 
+		disableAbilityItem(ITEMS.THROW_MONEY);
+
 		goToLaneWithBestTarget();
 
 		useGoodLuckCharmIfRelevant();
@@ -885,8 +887,6 @@ function goToLaneWithBestTarget() {
 				disableAbilityItem(ITEMS.MAXIMIZE_ELEMENT);
 				// Reflect Damage
 				disableAbilityItem(ITEMS.REFLECT_DAMAGE);
-				// Throw Money at Screen
-				disableAbilityItem(ITEMS.THROW_MONEY);
 			} else {
 				// Morale
 				enableAbility(ABILITIES.MORALE_BOOSTER);
@@ -908,8 +908,6 @@ function goToLaneWithBestTarget() {
 				enableAbilityItem(ITEMS.MAXIMIZE_ELEMENT);
 				// Reflect Damage
 				enableAbilityItem(ITEMS.REFLECT_DAMAGE);
-				// Throw Money at Screen
-				enableAbilityItem(ITEMS.THROW_MONEY);
 			}
 			
 			


### PR DESCRIPTION
At higher gold amounts, 10% can take a large chunk out if you are saving
up. In my opinion, we should just disable it forever.
