### PR TITLE
Reload page if autoRefresh is enabled and game doesn't fully load in 30s

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1383,14 +1383,15 @@ w.SteamDB_Minigame_Timer = w.setInterval(function(){
 		w.clearInterval(w.SteamDB_Minigame_Timer);
 		firstRun();
 		w.SteamDB_Minigame_Timer = w.setInterval(MainLoop, 1000);
-	} else { // reload page if game isn't fully loaded
-		w.setTimeout(function(){
-			if (!s().m_rgGameData) { // m_rgGameData is 'undefined' if stuck at 97/97
-				w.location.reload(true);
-			}
-		},autoRefreshCheckLoadedDelay*1000);
 	}
 }, 1000);
+
+// reload page if game isn't fully loaded, regardless of autoRefresh setting
+w.setTimeout(function(){
+	if (!s().m_rgGameData) { // m_rgGameData is 'undefined' if stuck at 97/97 or below
+		w.location.reload(true);
+	}
+},autoRefreshCheckLoadedDelay*1000);
 
 // Append gameid to breadcrumbs
 var breadcrumbs = document.querySelector('.breadcrumbs');

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -35,6 +35,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var autoRefreshMinutes = 30;
 var autoRefreshMinutesRandomDelay = 10;
+var autoRefreshCheckLoadedDelay = 30; // seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -1382,6 +1383,12 @@ w.SteamDB_Minigame_Timer = w.setInterval(function(){
 		w.clearInterval(w.SteamDB_Minigame_Timer);
 		firstRun();
 		w.SteamDB_Minigame_Timer = w.setInterval(MainLoop, 1000);
+	} else { // reload page if game isn't fully loaded
+		w.setTimeout(function(){
+			if (!s().m_rgGameData) { // m_rgGameData is 'undefined' if stuck at 97/97
+				w.location.reload(true);
+			}
+		},autoRefreshCheckLoadedDelay*1000);
 	}
 }, 1000);
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -35,6 +35,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var autoRefreshMinutes = 30;
 var autoRefreshMinutesRandomDelay = 10;
+var autoRefreshCheckLoadedDelay = 30; // seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -482,6 +483,12 @@ function autoRefreshPage(autoRefreshMinutes){
 	refreshTimer = setTimeout(function() {
 		autoRefreshHandler();
 	}, timerValue);
+
+	setTimeout(function() {
+		// m_rgGameData is 'undefined' if stuck at 97/97; only run this check if autoRefresh is enabled
+		if (!g_Minigame.CurrentScene().m_rgGameData)
+			window.location.reload();
+	},autoRefreshCheckLoadedDelay*1000);
 }
 
 function autoRefreshHandler() {

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -35,7 +35,6 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var autoRefreshMinutes = 30;
 var autoRefreshMinutesRandomDelay = 10;
-var autoRefreshCheckLoadedDelay = 30; // seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -483,12 +482,6 @@ function autoRefreshPage(autoRefreshMinutes){
 	refreshTimer = setTimeout(function() {
 		autoRefreshHandler();
 	}, timerValue);
-
-	setTimeout(function() {
-		// m_rgGameData is 'undefined' if stuck at 97/97; only run this check if autoRefresh is enabled
-		if (!g_Minigame.CurrentScene().m_rgGameData)
-			w.location.reload(true);
-	},autoRefreshCheckLoadedDelay*1000);
 }
 
 function autoRefreshHandler() {

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -487,7 +487,7 @@ function autoRefreshPage(autoRefreshMinutes){
 	setTimeout(function() {
 		// m_rgGameData is 'undefined' if stuck at 97/97; only run this check if autoRefresh is enabled
 		if (!g_Minigame.CurrentScene().m_rgGameData)
-			window.location.reload();
+			w.location.reload(true);
 	},autoRefreshCheckLoadedDelay*1000);
 }
 


### PR DESCRIPTION
closes https://github.com/SteamDatabase/steamSummerMinigame/issues/139

I've verified that it won't cause issues while players wait for a room to fill, but have not discovered/thought of any other edge cases.

Tested in Chrome + Tampermonkey.

![image](https://cloud.githubusercontent.com/assets/6096547/8159420/54fd40da-131b-11e5-9225-a7811f947128.png)

Fix is inserted into the autoRefreshPage so that it only runs if a user has the option enabled.
(i.e. won't run if pasted into console)
