### PR TITLE
Updated gold rain lane targeting

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -924,7 +924,7 @@ function goToLaneWithBestTarget(level) {
 			var potential = 0;
 			// Loop through lanes by elemental preference
 			var sortedLanes = sortLanesByElementals();
-			for(var notI = 0; notI < sortedLanes.length; notI++){
+			for(var notI = 0; notI < sortedLanes.length; notI++) {
 				// Maximize compability with upstream
 				i = sortedLanes[notI];
 				// ignore if lane is empty
@@ -934,15 +934,22 @@ function goToLaneWithBestTarget(level) {
 				var stacks = 0;
 				if(typeof s().m_rgLaneData[i].abilities[ABILITIES.RAINING_GOLD] != 'undefined') {
 					stacks = s().m_rgLaneData[i].abilities[ABILITIES.RAINING_GOLD];
-					advLog('stacks: ' + stacks, 3);
-				}
-				for(var m = 0; m < s().m_rgEnemies.length; m++) {
-					var enemyGold = s().m_rgEnemies[m].m_data.gold;
-					if (stacks * enemyGold > potential) {
-						potential = stacks * enemyGold;
-						preferredTarget = s().m_rgEnemies[m].m_nID;
-						preferredLane = i;
+					advLog('[Gold rain] stacks: ' + stacks, 5);
+
+					for(var m = 0; m < s().m_rgEnemies.length; m++){
+						if(s().m_rgEnemies[m].m_nLane != i){
+							continue;
+						}
+						advLog("[Gold rain] An enemy exists in raining gold lane: " + (i + 1), 5);
+						var enemyGold = s().m_rgEnemies[m].m_data.gold;
+						if(stacks * enemyGold > potential) {
+							potential = stacks * enemyGold;
+							preferredTarget = s().m_rgEnemies[m].m_nID;
+							preferredLane = i;
+						}
 					}
+					advLog("[Gold rain] preferredLane: " + preferredLane, 5);
+					advLog("[Gold rain] preferredTarget: " +  preferredTarget, 5);
 				}
 			}
 		}


### PR DESCRIPTION
Wrong behavior: Currently checks ALL enemies if they are a worthy target.
Changes include: Do not consider an enemy for a gold rain target unless it is in the gold rain lane. Moved the for loop block of code into the if block of whether a gold rain ability is active.

Noticed by @armetilou here: https://github.com/wchill/steamSummerMinigame/issues/56#issuecomment-111974727
