### PR TITLE
Prevent duplicate Max Elemental Damage use

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1297,9 +1297,9 @@ function useAbilities(level)
 	}
 
 	// Max Elemental
-	if (tryUsingAbility(ABILITIES.MAX_ELEMENTAL_DAMAGE, true)) {
+	if (typeof s().m_rgLaneData[i].abilities[ABILITIES.MAX_ELEMENTAL_DAMAGE] == 'undefined' && tryUsingAbility(ABILITIES.MAX_ELEMENTAL_DAMAGE, true)) {
 		// Max Elemental Damage is purchased, cooled down, and needed. Trigger it.
-		advLog('Max Elemental Damage is purchased and cooled down, triggering it.', 2);
+		advLog('Max Elemental Damage is purchased, cooled down, and not active in lane, triggering it.', 2);
 	}
 
 	// Wormhole

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1297,7 +1297,7 @@ function useAbilities(level)
 	}
 
 	// Max Elemental
-	if (typeof s().m_rgLaneData[i].abilities[ABILITIES.MAX_ELEMENTAL_DAMAGE] == 'undefined' && tryUsingAbility(ABILITIES.MAX_ELEMENTAL_DAMAGE, true)) {
+	if (typeof s().m_rgLaneData[s().m_rgPlayerData.current_lane].abilities[ABILITIES.MAX_ELEMENTAL_DAMAGE] == 'undefined' && tryUsingAbility(ABILITIES.MAX_ELEMENTAL_DAMAGE, true)) {
 		// Max Elemental Damage is purchased, cooled down, and needed. Trigger it.
 		advLog('Max Elemental Damage is purchased, cooled down, and not active in lane, triggering it.', 2);
 	}


### PR DESCRIPTION
Checks of Max Elemental Damage ability is already in use in lane before activating.  This prevents wasteful uses as this ability does not stack.
