### PR TITLE
'char' is reserved and shouldn't be used

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -823,14 +823,14 @@ function lockElements() {
 	];
 
 	var hashCode=function(str) {
-		var t=0, i, char;
+		var t=0, i, ch;
 		if (0 === str.length) {
 			return t;
 		}
 
 		for (i=0; i<str.length; i++) {
-			char=str.charCodeAt(i);
-			t=(t<<5)-t+char;
+			ch=str.charCodeAt(i);
+			t=(t<<5)-t+ch;
 			t&=t;
 		}
 


### PR DESCRIPTION
'char' is reserved in javascript, so it should be replaced with another var name, in this case, `ch`.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
