### PR TITLE
Avoid wasting raining gold

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1326,7 +1326,7 @@ function useAbilities(level, timeLeft)
 
 		tryUsingAbility(ABILITIES.DECREASE_COOLDOWNS, true);
 		tryUsingAbility(ABILITIES.WORMHOLE);
-		tryUsingAbility(ABILITIES.RAINING_GOLD);
+		// Since we are disabling auto clicker in wormhole levels, we should not waste raining golds here
 
 		// Exit right now so we don't use any other abilities after wormhole
 		return;


### PR DESCRIPTION
Since we are disabling auto clicker in wormhole levels, we should not waste raining gold when nobody is clicking
