### PR TITLE
Take diminishing returns into account for click damage upgrades

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -574,14 +574,25 @@ function useAutoUpgrade() {
 	s().m_rgTuningData.upgrades.forEach(function(upg, idx) {
 		if(upg_map.hasOwnProperty(upg.type)) {
 
-			var cost = s().GetUpgradeCost(idx) / parseFloat(upg.multiplier);
+			var multiplier;
+			switch(upg.type) {
+				case 2: // Type for click damage. All tiers.
+					var new_damage = pTree.damage_per_click + pTree.base_dps * parseFloat(upg.multiplier);
+					multiplier = new_damage / pTree.damage_per_click;
+					break;
+				default:
+					multiplier = parseFloat(upg.multiplier);
+					break;
+			}
+			var cost_per_mult = s().GetUpgradeCost(idx) / multiplier;
 
-			if(!upg_map[upg.type].hasOwnProperty('idx') || upg_map[upg.type].cost_per_mult > cost) {
+			if(!upg_map[upg.type].hasOwnProperty('idx') || upg_map[upg.type].cost_per_mult > cost_per_mult) {
+				// skip this upgrade if another upgrade is required at a certain level
 				if(upg.hasOwnProperty('required_upgrade') && s().GetUpgradeLevel(upg.required_upgrade) < upg.required_upgrade_level) { return; }
 
 				upg_map[upg.type] = {
 					'idx': idx,
-					'cost_per_mult': cost,
+					'cost_per_mult': cost_per_mult,
 				};
 			}
 		}


### PR DESCRIPTION
This PR will calculate the damage increase of an upgrade based on the actual dps instead of just a multiplier. In effect this takes diminishing returns into account because each update will result in less actual damage increase. For example:

```
Skill with a multiplier of 1000 at level 5
10*1000*5 = 50k damage
Skill with a multiplier of 1000 at level 6
10*1000*6 = 60k damage
actual multiplier = (60k - 50k) / 50k = 20% increase

Skill with a multiplier of 1000 at level 10
10*1000*10 = 100k damage
Skill with a multiplier of 1000 at level 11
10*1000*11 = 110k damage
actual multiplier = (110k - 100k) / 100k = 10% increase
```

In practice this commit will has a slight preference of lower upgrades compared to the previous method.

_This could also be calculated for auto dps and crit but I don't have time for that today. I'll also do some more testing tomorrow if it has the intended effect_
