### PR TITLE
Change disabling of autoclick from every 500 rounds to every wormhole round

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -439,7 +439,7 @@ function MainLoop() {
 		useAutoUpgrade();
 		useAutoPurchaseAbilities();
 
-		if(level > CONTROL.goldholeThreshold && level % 500 === 0) {
+		if(level > CONTROL.goldholeThreshold && level % CONTROL.wormholeRounds === 0) {
 			advLog('Skipping autoclick on wormhole boss farm.');
 		} else {
 			s().m_nClicks += currentClickRate;


### PR DESCRIPTION
Currently, autoclick is disabled every 500 rounds, but it should be disabled every round that is known as a wormhole round. This fixes the check so that every wormhole round will have autoclick disabled to optimize wormhole use.
